### PR TITLE
Assert a pattern is a string.

### DIFF
--- a/source/stdlib/regexp.js
+++ b/source/stdlib/regexp.js
@@ -51,7 +51,8 @@ RegExpParser.prototype.parse = function (
     pattern
 )
 {
-    assert(typeof pattern === "string");
+    if (typeof pattern === "string")
+        throw "Patterns should be strings"
     this.pattern = pattern;
 
     // Init current char cursor.

--- a/source/stdlib/regexp.js
+++ b/source/stdlib/regexp.js
@@ -51,6 +51,7 @@ RegExpParser.prototype.parse = function (
     pattern
 )
 {
+    assert(typeof pattern === "string");
     this.pattern = pattern;
 
     // Init current char cursor.


### PR DESCRIPTION
It makes debugging easier, as we don't go into other functions before raising an error (in `RegExpParser.prototype.advance`, actually)
